### PR TITLE
Consistently close channel on error

### DIFF
--- a/client.go
+++ b/client.go
@@ -63,6 +63,7 @@ func (c *Client) Subscribe(stream string, handler func(msg *Event)) error {
 func (c *Client) SubscribeChan(stream string, ch chan *Event) error {
 	resp, err := c.request(stream)
 	if err != nil {
+		close(ch)
 		return err
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
The subscription events channel was only closed in the case where an error was encountered while reading from the stream, but not in the case such error was encountered while connecting to it.