### PR TITLE
Adds AutoReplay option to Stream

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -6,6 +6,8 @@ package sse
 
 // Stream ...
 type Stream struct {
+	// Enables replaying of eventlog to newly added subscribers
+	AutoReplay  bool
 	stats       chan chan int
 	subscribers []*Subscriber
 	register    chan *Subscriber
@@ -24,6 +26,7 @@ type StreamRegistration struct {
 // newStream returns a new stream
 func newStream(bufsize int) *Stream {
 	return &Stream{
+		AutoReplay:  true,
 		subscribers: make([]*Subscriber, 0),
 		register:    make(chan *Subscriber),
 		deregister:  make(chan *Subscriber),
@@ -40,7 +43,9 @@ func (str *Stream) run() {
 			// Add new subscriber
 			case subscriber := <-str.register:
 				str.subscribers = append(str.subscribers, subscriber)
-				str.eventlog.Replay(subscriber)
+				if str.AutoReplay {
+					str.eventlog.Replay(subscriber)
+				}
 
 			// Remove closed subscriber
 			case subscriber := <-str.deregister:

--- a/stream_test.go
+++ b/stream_test.go
@@ -35,6 +35,16 @@ func TestStream(t *testing.T) {
 			})
 		})
 
+		Convey("When adding a subscriber with auto replay disabled", func() {
+			s.AutoReplay = false
+			s.event <- &Event{Data: []byte("test")}
+			sub := s.addSubscriber("0")
+
+			Convey("It should not receive the eventlog", func() {
+				So(len(sub.connection), ShouldEqual, 0)
+			})
+		})
+
 		Convey("When removing a subscriber", func() {
 			s.addSubscriber("0")
 			time.Sleep(time.Millisecond * 100)
@@ -84,5 +94,4 @@ func TestStream(t *testing.T) {
 
 		})
 	})
-
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -21,17 +21,23 @@ func TestStream(t *testing.T) {
 		s.run()
 
 		Convey("When adding a subscriber", func() {
+			s.event <- &Event{Data: []byte("test")}
 			sub := s.addSubscriber("0")
 
 			Convey("It should be stored", func() {
 				So(len(s.subscribers), ShouldEqual, 1)
 			})
+
 			Convey("It should receive messages", func() {
 				s.event <- &Event{Data: []byte("test")}
 				msg, err := wait(sub.connection, time.Second*1)
 
 				So(err, ShouldBeNil)
 				So(string(msg), ShouldEqual, "test")
+			})
+
+			Convey("It should receive the eventlog", func() {
+				So(len(sub.connection), ShouldEqual, 1)
 			})
 		})
 
@@ -91,7 +97,6 @@ func TestStream(t *testing.T) {
 
 				So(len(s.subscribers), ShouldEqual, 0)
 			})
-
 		})
 	})
 }


### PR DESCRIPTION
Adds a boolean flag to the Stream struct to allow enabling/disabling of replaying the eventlog to newly added subscribers.

Ensures backward-compatibility of functionality by defaulting the AutoReplay flag to true, which would emulate past behaviour.

Also added tests for when AutoReplay is both enabled and disabled.

Let us know if there's anything to be improved as part of this PR.