### PR TITLE
Fixes AutoReplay disabled test

### DIFF
--- a/stream_test.go
+++ b/stream_test.go
@@ -44,6 +44,7 @@ func TestStream(t *testing.T) {
 		Convey("When adding a subscriber with auto replay disabled", func() {
 			s.AutoReplay = false
 			s.event <- &Event{Data: []byte("test")}
+			time.Sleep(time.Millisecond * 100)
 			sub := s.addSubscriber("0")
 
 			Convey("It should not receive the eventlog", func() {


### PR DESCRIPTION
Added a sleep before adding the subscriber to the stream to ensure the event is acknowledged before the subscriber is added.

The test should now pass consistently.