### PR TITLE
Update HTTPHandler to send events with new-line seperation

### DIFF
--- a/http.go
+++ b/http.go
@@ -70,6 +70,7 @@ func (s *Server) HTTPHandler(w http.ResponseWriter, r *http.Request) {
 			if len(ev.Data) > 0 {
 				fmt.Fprintf(w, "data: %s\n", ev.Data)
 			}
+			fmt.Fprint(w, "\n")
 			flusher.Flush()
 		}
 	}


### PR DESCRIPTION
My team and I ran into an issue with subscribing to the HTTPHandler from a web client. It seems like the existing format for the event doesn't match [the W3 recommendation](https://www.w3.org/TR/eventsource/).

W3 specifies that there should be a an empty new-line character between events.

For example:
```
id: 0
event: add
data: this is the first event

id: 1
event: add
data: this is the second event

id: 2
event: add
data: this is the third event
```

Currently the HTTPHandler doesn't new-line separate.

For example:
```
id: 0
event: add
data: this is the first event
id: 1
event: add
data: this is the second event
id: 2
event: add
data: this is the third event
```

The existing client in this library doesn't care about this distinction, but a web browser such as Chrome or Safari or a JS client can't parse the events. Adding a new-line fixes this.

Making this change doesn't effect the current client because [it defaults to no behavior](https://github.com/r3labs/sse/blob/master/client.go#L162-L163).