### PR TITLE
Closing client connection when Unsubscribe() is called.

### DIFF
--- a/client.go
+++ b/client.go
@@ -99,6 +99,7 @@ func (c *Client) SubscribeChan(stream string, ch chan *Event) error {
 				if msg != nil {
 					select {
 					case <-c.subscribed[ch]:
+						resp.Body.Close()
 						return
 					default:
 						ch <- msg


### PR DESCRIPTION
This should prevent the issue where the connection isn't closed when unsubscribing.