### PR TITLE
fixing memory leak when creating a new stream

### DIFF
--- a/server.go
+++ b/server.go
@@ -48,16 +48,15 @@ func (s *Server) Close() {
 
 // CreateStream will create a new stream and register it
 func (s *Server) CreateStream(id string) *Stream {
-	str := newStream(s.BufferSize, s.AutoReplay)
-	str.run()
-
-	// Register new stream
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if s.Streams[id] != nil {
 		return s.Streams[id]
 	}
+
+	str := newStream(s.BufferSize, s.AutoReplay)
+	str.run()
 
 	s.Streams[id] = str
 

--- a/server_test.go
+++ b/server_test.go
@@ -6,6 +6,7 @@ package sse
 
 import (
 	"errors"
+	"runtime"
 	"testing"
 	"time"
 
@@ -37,6 +38,18 @@ func TestServer(t *testing.T) {
 				So(s.getStream("test"), ShouldNotBeNil)
 			})
 			Convey("It should be started", func() {
+			})
+		})
+
+		Convey("When creating a stream that already exists", func() {
+			numGoRoutines := runtime.NumGoroutine()
+			s.CreateStream("test")
+
+			Convey("It should still be stored", func() {
+				So(s.getStream("test"), ShouldNotBeNil)
+			})
+			Convey("The number of goroutines should not increase", func() {
+				So(runtime.NumGoroutine(), ShouldEqual, numGoRoutines)
 			})
 		})
 


### PR DESCRIPTION
## Bug Description
When creating a stream via `CreateStream()`, a new stream is always created even if a stream with the same `id` already exists, causing a memory leak where goroutines are created via `str.run()` but never closed.

## How to Read This PR
Instead of closing the newly created stream if it exists, this PR fixes the bug by reorganizing the `CreateStream()` function so that it checks to see if the server has a stream with the given `id` before creating a new stream. 

## How to Test This PR
These changes are reflected in the tests!

```
make test
```
