### PR TITLE
enable empty event lines

### DIFF
--- a/client.go
+++ b/client.go
@@ -215,21 +215,16 @@ func (c *Client) processEvent(msg []byte) (event *Event, err error) {
 	// Trim the last "\n" per the spec.
 	e.Data = bytes.TrimSuffix(e.Data, []byte("\n"))
 
-	if len(e.Data) > 0 {
-		if c.EncodingBase64 {
-			buf := make([]byte, base64.StdEncoding.DecodedLen(len(e.Data)))
+	if c.EncodingBase64 {
+		buf := make([]byte, base64.StdEncoding.DecodedLen(len(e.Data)))
 
-			_, err := base64.StdEncoding.Decode(buf, e.Data)
-			if err != nil {
-				err = fmt.Errorf("failed to decode event message: %s", err)
-			}
-			e.Data = buf
+		_, err := base64.StdEncoding.Decode(buf, e.Data)
+		if err != nil {
+			err = fmt.Errorf("failed to decode event message: %s", err)
 		}
-		return &e, err
+		e.Data = buf
 	}
-
-	// If we made it here, then the event had a problem.
-	return nil, errors.New("invalid event message")
+	return &e, err
 }
 
 func (c *Client) cleanup(resp *http.Response, ch chan *Event) {
@@ -254,7 +249,7 @@ func trimHeader(size int, data []byte) []byte {
 		data = data[1:]
 	}
 	// Remove trailing new line
-	if data[len(data)-1] == 10 {
+	if len(data) > 0 && data[len(data)-1] == 10 {
 		data = data[:len(data)-1]
 	}
 	return data


### PR DESCRIPTION
if publishing an empty string (which can happen in our use case since we are passing output from a cli command):
```
server.Publish("messages", &sse.Event{
    Data: []byte(""),
})
```
and subscribing to the event:
```
client.Subscribe("messages", func(msg *sse.Event) {
    // Got some data!
    fmt.Println(msg.Data)
})
```
causes a panic (index is out of range) when calling `trimHeader`. the empty byte slice results in `data[-1]`

i've also removed the length check in processEvent to display empty lines. AFAIK empty strings are allowed according to the W3C.