### PR TITLE
Issue #48: panic: unsafe map write when calling client.SubscribeChan() multiple times (concurrently) with the same channel.

### DIFF
--- a/client.go
+++ b/client.go
@@ -96,7 +96,9 @@ func (c *Client) Subscribe(stream string, handler func(msg *Event)) error {
 func (c *Client) SubscribeChan(stream string, ch chan *Event) error {
 	var connected bool
 	errch := make(chan error)
+	c.mu.Lock()
 	c.subscribed[ch] = make(chan bool)
+	c.mu.Unlock()
 
 	go func() {
 		operation := func() error {


### PR DESCRIPTION
Wrapped access to subscribed map in mutex.

See https://github.com/r3labs/sse/issues/48