### PR TITLE
Add context aware apis for better lifecycle management

### DIFF
--- a/event.go
+++ b/event.go
@@ -7,6 +7,7 @@ package sse
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"io"
 	"time"
 )
@@ -67,6 +68,9 @@ func (e *EventStreamReader) ReadEvent() ([]byte, error) {
 		return event, nil
 	}
 	if err := e.scanner.Err(); err != nil {
+		if err == context.Canceled {
+			return nil, io.EOF
+		}
 		return nil, err
 	}
 	return nil, io.EOF


### PR DESCRIPTION
We cannot cancel the subscription with current api. This PR adds context aware apis and also keep current apis backward compatible.