### PR TITLE
use Last-Event-ID as int, not string

### DIFF
--- a/event_log.go
+++ b/event_log.go
@@ -27,7 +27,8 @@ func (e *EventLog) Clear() {
 // Replay events to a subscriber
 func (e *EventLog) Replay(s *Subscriber) {
 	for i := 0; i < len((*e)); i++ {
-		if string((*e)[i].ID) >= s.eventid {
+		id, _ := strconv.Atoi(string((*e)[i].ID))
+		if id >= s.eventid {
 			s.connection <- (*e)[i]
 		}
 	}

--- a/http.go
+++ b/http.go
@@ -7,6 +7,7 @@ package sse
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 )
 
@@ -39,9 +40,14 @@ func (s *Server) HTTPHandler(w http.ResponseWriter, r *http.Request) {
 		stream = s.CreateStream(streamID)
 	}
 
-	eventid := r.Header.Get("Last-Event-ID")
-	if eventid == "" {
-		eventid = "0"
+	eventid := 0
+	if id := r.Header.Get("Last-Event-ID"); id != "" {
+		var err error
+		eventid, err = strconv.Atoi(id)
+		if err != nil {
+			http.Error(w, "Last-Event-ID must be a number!", http.StatusBadRequest)
+			return
+		}
 	}
 
 	// Create the stream subscriber

--- a/stream.go
+++ b/stream.go
@@ -87,7 +87,7 @@ func (str *Stream) getSubIndex(sub *Subscriber) int {
 }
 
 // addSubscriber will create a new subscriber on a stream
-func (str *Stream) addSubscriber(eventid string) *Subscriber {
+func (str *Stream) addSubscriber(eventid int) *Subscriber {
 	sub := &Subscriber{
 		eventid:    eventid,
 		quit:       str.deregister,

--- a/subscriber.go
+++ b/subscriber.go
@@ -6,7 +6,7 @@ package sse
 
 // Subscriber ...
 type Subscriber struct {
-	eventid    string
+	eventid    int
 	quit       chan *Subscriber
 	connection chan *Event
 }


### PR DESCRIPTION
As string comparision isn't nature than number, and will send wrong message while set Last-Event-ID to number.

scenario:
1. message id is 100
2. send http request with Last-Event-ID=10
3. server will send messages as follow: 2,3,4,5,6,7,8,9,11,12...