### PR TITLE
Handle more permutations of newlines

### DIFF
--- a/event.go
+++ b/event.go
@@ -37,14 +37,8 @@ func NewEventStreamReader(eventStream io.Reader) *EventStreamReader {
 		}
 
 		// We have a full event payload to parse.
-		if i := bytes.Index(data, []byte("\r\n\r\n")); i >= 0 {
-			return i + 1, data[0:i], nil
-		}
-		if i := bytes.Index(data, []byte("\r\r")); i >= 0 {
-			return i + 1, data[0:i], nil
-		}
-		if i := bytes.Index(data, []byte("\n\n")); i >= 0 {
-			return i + 1, data[0:i], nil
+		if i, nlen := containsDoubleNewline(data); i >= 0 {
+			return i + nlen, data[0:i], nil
 		}
 		// If we're at EOF, we have all of the data.
 		if atEOF {
@@ -59,6 +53,43 @@ func NewEventStreamReader(eventStream io.Reader) *EventStreamReader {
 	return &EventStreamReader{
 		scanner: scanner,
 	}
+}
+
+// Returns a tuple containing the index of a double newline, and the number of bytes
+// represented by that sequence. If no double newline is present, the first value
+// will be negative.
+func containsDoubleNewline(data []byte) (int, int) {
+	// Search for each potentially valid sequence of newline characters
+	crcr := bytes.Index(data, []byte("\r\r"))
+	lflf := bytes.Index(data, []byte("\n\n"))
+	crlflf := bytes.Index(data, []byte("\r\n\n"))
+	lfcrlf := bytes.Index(data, []byte("\n\r\n"))
+	crlfcrlf := bytes.Index(data, []byte("\r\n\r\n"))
+	// Find the earliest position of a double newline combination
+	minPos := minPosInt(crcr, minPosInt(lflf, minPosInt(crlflf, minPosInt(lfcrlf, crlfcrlf))))
+	// Detemine the length of the sequence
+	nlen := 2
+	if minPos == crlfcrlf {
+		nlen = 4
+	} else if minPos == crlflf || minPos == lfcrlf {
+		nlen = 3
+	}
+	return minPos, nlen
+}
+
+// Returns the minimum non-negative value out of the two values. If both
+// are negative, a negative value is returned.
+func minPosInt(a, b int) int {
+	if a < 0 {
+		return b
+	}
+	if b < 0 {
+		return a
+	}
+	if a > b {
+		return b
+	}
+	return a
 }
 
 // ReadEvent scans the EventStream for events.


### PR DESCRIPTION
The SSE spec defines `CR` (`\r`), `LF` (`\n`) and `CRLF` (`\r\n`) as permitted end-of-line sequences.  However, it does not state that a producer must pick one and use only that format - it is possible to encounter `\r\n\n` or `\n\r\n`.  This project currently does not recognize those permutations.

This patch detects the earliest occurrence of any of the (sensible) permutations, and advances the stream by the length of that sequence.  By sensible permutations, I am assuming that `\r` won't be mixed in with any of the other possible sequences, as I believe it is rarely used now.

I tested it against two SSE sources: one that sends only `\n\n` and one that sends `\n\r\n`, and it behaves correctly for both.