### PR TITLE
ResponseValidator & ReconnectNotify

### DIFF
--- a/client.go
+++ b/client.go
@@ -83,9 +83,9 @@ func (c *Client) SubscribeWithContext(ctx context.Context, stream string, handle
 	// Apply user specified reconnection strategy or default to standard NewExponentialBackOff() reconnection method
 	var err error
 	if c.ReconnectStrategy != nil {
-		err = backoff.Retry(operation, c.ReconnectStrategy)
+		err = backoff.RetryNotify(operation, c.ReconnectStrategy, c.ReconnectNotify)
 	} else {
-		err = backoff.Retry(operation, backoff.NewExponentialBackOff())
+		err = backoff.RetryNotify(operation, backoff.NewExponentialBackOff(), c.ReconnectNotify)
 	}
 	return err
 }

--- a/client.go
+++ b/client.go
@@ -39,6 +39,7 @@ type Client struct {
 	EventID           string
 	disconnectcb      ConnCallback
 	ReconnectStrategy backoff.BackOff
+	ReconnectNotify   backoff.Notify
 	mu                sync.Mutex
 }
 
@@ -150,9 +151,9 @@ func (c *Client) SubscribeChanWithContext(ctx context.Context, stream string, ch
 		// Apply user specified reconnection strategy or default to standard NewExponentialBackOff() reconnection method
 		var err error
 		if c.ReconnectStrategy != nil {
-			err = backoff.Retry(operation, c.ReconnectStrategy)
+			err = backoff.RetryNotify(operation, c.ReconnectStrategy, c.ReconnectNotify)
 		} else {
-			err = backoff.Retry(operation, backoff.NewExponentialBackOff())
+			err = backoff.RetryNotify(operation, backoff.NewExponentialBackOff(), c.ReconnectNotify)
 		}
 
 		// channel closed once connected


### PR DESCRIPTION
Given the code
```golang
// in a goroutine:
for {
	err := client.SubscribeRawWithContext(ctx, func(msg *sse.Event) {
		logger.Printf("SSE Message ID=%q Retry=%q Event=%q len(Data)=%d\n", string(msg.ID), string(msg.Retry), string(msg.Event), len(msg.Data))
	})
	if err != nil {
		logger.Println("SubscribeRawWithContext stopped:", err)
	} else {
		logger.Println("SubscribeRawWithContext done; retrying")
		time.Sleep(1 * time.Second)
	}
}

```

the SubscribeRawWithContext method would be called every 1 second if the HTTP request returns a StatusCode other than 200 without a stream result. This happens because the EventStreamReader.startReadLoop will convert `io.EOF` into a non-error. This gives the users of the SSE lib no context as to why the `SubscribeRawWithContext` is called every single second (and without the Sleep even continuously).

I made 2 adjustments:
- [x] use RetryNotify of the backoff library, to enable possibly getting feedback when a retry happens
- [x] add a ResponseValidator callback that can return an error based on an invalid HTTP response (like not `text/event-stream` or not `200 OK`)

Users can do:
```golang
client.ResponseValidator = func(c *sse.Client, resp *http.Response) error {
	if resp.Header.Get("Content-Type") != "text/event-stream" || resp.StatusCode != 200 {
		return fmt.Errorf("Invalid StatusCode %d: %s", resp.StatusCode, resp.Status)
	}
	return nil
}
```
and 
```golang
client.ReconnectNotify = func(err error, backoff time.Duration) {
	logger.Println("Reconnect", err, backoff)
}
```

Without a ResponseValidator this is fully backwards compatible.