### PR TITLE
Fix client trimHeader crash for header only data

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ SSE is a client/server implementation for Server Side Events for Golang. Right n
 To install:
 
 ```sh
-$ go get github.com/r3labs/sse
+$ go get github.com/foolenough/sse
 ```
 
 To Test:

--- a/client.go
+++ b/client.go
@@ -333,6 +333,9 @@ func (c *Client) cleanup(ch chan *Event) {
 
 func trimHeader(size int, data []byte) []byte {
 	data = data[size:]
+	if len(data) == 0 {
+		return data
+	}
 	// Remove optional leading whitespace
 	if data[0] == 32 {
 		data = data[1:]

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/r3labs/sse
+module github.com/foolenough/sse
 
 go 1.13
 


### PR DESCRIPTION
If data is empty after remove header, return.