### PR TITLE
Remove "Access-Control-Allow-Origin" from NewServer Headers

### DIFF
--- a/server.go
+++ b/server.go
@@ -39,9 +39,7 @@ func New() *Server {
 		AutoStream: false,
 		AutoReplay: true,
 		Streams:    make(map[string]*Stream),
-		Headers: map[string]string{
-			"Access-Control-Allow-Origin": "*",
-		},
+		Headers: map[string]string{},
 	}
 }
 


### PR DESCRIPTION
Remove "Access-Control-Allow-Origin" from NewServer Headers.

It has many implications like this error:

```
Access to resource at 'http://localhost:3000/streams/v1?stream=test' from origin 'http://localhost:5000' has been blocked by CORS policy: The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'.
```