### PR TITLE
remove stream if AutoStream enabled when no more subscribers

### DIFF
--- a/http.go
+++ b/http.go
@@ -64,7 +64,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		sub.close()
 
-		if s.AutoStream && len(stream.subscribers) == 0 {
+		if s.AutoStream && !s.AutoReplay && stream.getSubscriberCount() == 0 {
 			s.RemoveStream(streamID)
 		}
 	}()

--- a/http.go
+++ b/http.go
@@ -61,7 +61,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	go func() {
 		<-r.Context().Done()
+
 		sub.close()
+
+		if s.AutoStream && len(stream.subscribers) == 0 {
+			s.RemoveStream(streamID)
+		}
 	}()
 
 	flusher.Flush()

--- a/http_test.go
+++ b/http_test.go
@@ -191,6 +191,8 @@ func TestHTTPStreamHandlerAutoStream(t *testing.T) {
 	sseServer := New()
 	defer sseServer.Close()
 
+	sseServer.AutoReplay = false
+
 	sseServer.AutoStream = true
 
 	mux := http.NewServeMux()

--- a/http_test.go
+++ b/http_test.go
@@ -201,16 +201,13 @@ func TestHTTPStreamHandlerAutoStream(t *testing.T) {
 
 	events := make(chan *Event)
 
-	var cErr error
+	cErr := make(chan error)
 
 	go func() {
-		cErr = c.SubscribeChan("test", events)
+		cErr <- c.SubscribeChan("test", events)
 	}()
 
-	// Wait for subscriber to be registered and message to be published
-	time.Sleep(1 * time.Second)
-
-	require.Nil(t, cErr)
+	require.Nil(t, <-cErr)
 
 	sseServer.Publish("test", &Event{Data: []byte("test")})
 
@@ -222,7 +219,7 @@ func TestHTTPStreamHandlerAutoStream(t *testing.T) {
 
 	c.Unsubscribe(events)
 
-	time.Sleep(1 * time.Second)
+	_, _ = wait(events, 1*time.Second)
 
 	assert.Equal(t, (*Stream)(nil), sseServer.getStream("test"))
 }

--- a/http_test.go
+++ b/http_test.go
@@ -184,3 +184,45 @@ func TestHTTPStreamHandlerHeaderFlushIfNoEvents(t *testing.T) {
 		assert.Fail(t, "Subscribe should returned in 100 milliseconds")
 	}
 }
+
+func TestHTTPStreamHandlerAutoStream(t *testing.T) {
+	t.Parallel()
+
+	sseServer := New()
+	defer sseServer.Close()
+
+	sseServer.AutoStream = true
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/events", sseServer.ServeHTTP)
+	server := httptest.NewServer(mux)
+
+	c := NewClient(server.URL + "/events")
+
+	events := make(chan *Event)
+
+	var cErr error
+
+	go func() {
+		cErr = c.SubscribeChan("test", events)
+	}()
+
+	// Wait for subscriber to be registered and message to be published
+	time.Sleep(1 * time.Second)
+
+	require.Nil(t, cErr)
+
+	sseServer.Publish("test", &Event{Data: []byte("test")})
+
+	msg, err := wait(events, 1*time.Second)
+
+	require.Nil(t, err)
+
+	assert.Equal(t, []byte(`test`), msg)
+
+	c.Unsubscribe(events)
+
+	time.Sleep(1 * time.Second)
+
+	assert.Equal(t, (*Stream)(nil), sseServer.getStream("test"))
+}

--- a/server.go
+++ b/server.go
@@ -39,7 +39,7 @@ func New() *Server {
 		AutoStream: false,
 		AutoReplay: true,
 		Streams:    make(map[string]*Stream),
-		Headers: map[string]string{},
+		Headers:    map[string]string{},
 	}
 }
 
@@ -63,7 +63,7 @@ func (s *Server) CreateStream(id string) *Stream {
 		return s.Streams[id]
 	}
 
-	str := newStream(s.BufferSize, s.AutoReplay)
+	str := newStream(s.BufferSize, s.AutoReplay, s.AutoStream)
 	str.run()
 
 	s.Streams[id] = str

--- a/stream.go
+++ b/stream.go
@@ -18,6 +18,7 @@ type Stream struct {
 	event           chan *Event
 	quit            chan bool
 	subscriberCount int32
+	isAutoStream    bool
 }
 
 // StreamRegistration ...
@@ -27,15 +28,16 @@ type StreamRegistration struct {
 }
 
 // newStream returns a new stream
-func newStream(bufsize int, replay bool) *Stream {
+func newStream(bufsize int, replay, isAutoStream bool) *Stream {
 	return &Stream{
-		AutoReplay:  replay,
-		subscribers: make([]*Subscriber, 0),
-		register:    make(chan *Subscriber),
-		deregister:  make(chan *Subscriber),
-		event:       make(chan *Event, bufsize),
-		quit:        make(chan bool),
-		Eventlog:    make(EventLog, 0),
+		AutoReplay:   replay,
+		subscribers:  make([]*Subscriber, 0),
+		isAutoStream: isAutoStream,
+		register:     make(chan *Subscriber),
+		deregister:   make(chan *Subscriber),
+		event:        make(chan *Event, bufsize),
+		quit:         make(chan bool),
+		Eventlog:     make(EventLog, 0),
 	}
 }
 
@@ -96,7 +98,10 @@ func (str *Stream) addSubscriber(eventid int) *Subscriber {
 		eventid:    eventid,
 		quit:       str.deregister,
 		connection: make(chan *Event, 64),
-		removed:    make(chan struct{}, 1),
+	}
+
+	if str.isAutoStream {
+		sub.removed = make(chan struct{}, 1)
 	}
 
 	str.register <- sub
@@ -106,16 +111,20 @@ func (str *Stream) addSubscriber(eventid int) *Subscriber {
 func (str *Stream) removeSubscriber(i int) {
 	atomic.AddInt32(&str.subscriberCount, -1)
 	close(str.subscribers[i].connection)
-	str.subscribers[i].removed <- struct{}{}
-	close(str.subscribers[i].removed)
+	if str.subscribers[i].removed != nil {
+		str.subscribers[i].removed <- struct{}{}
+		close(str.subscribers[i].removed)
+	}
 	str.subscribers = append(str.subscribers[:i], str.subscribers[i+1:]...)
 }
 
 func (str *Stream) removeAllSubscribers() {
 	for i := 0; i < len(str.subscribers); i++ {
 		close(str.subscribers[i].connection)
-		str.subscribers[i].removed <- struct{}{}
-		close(str.subscribers[i].removed)
+		if str.subscribers[i].removed != nil {
+			str.subscribers[i].removed <- struct{}{}
+			close(str.subscribers[i].removed)
+		}
 	}
 	atomic.StoreInt32(&str.subscriberCount, 0)
 	str.subscribers = str.subscribers[:0]

--- a/stream_test.go
+++ b/stream_test.go
@@ -16,7 +16,7 @@ import (
 // Maybe fix this in the future so we can test with -race enabled
 
 func TestStreamAddSubscriber(t *testing.T) {
-	s := newStream(1024, true)
+	s := newStream(1024, true, false)
 	s.run()
 	defer s.close()
 
@@ -34,7 +34,7 @@ func TestStreamAddSubscriber(t *testing.T) {
 }
 
 func TestStreamRemoveSubscriber(t *testing.T) {
-	s := newStream(1024, true)
+	s := newStream(1024, true, false)
 	s.run()
 	defer s.close()
 
@@ -46,7 +46,7 @@ func TestStreamRemoveSubscriber(t *testing.T) {
 }
 
 func TestStreamSubscriberClose(t *testing.T) {
-	s := newStream(1024, true)
+	s := newStream(1024, true, false)
 	s.run()
 	defer s.close()
 
@@ -58,7 +58,7 @@ func TestStreamSubscriberClose(t *testing.T) {
 }
 
 func TestStreamDisableAutoReplay(t *testing.T) {
-	s := newStream(1024, true)
+	s := newStream(1024, true, false)
 	s.run()
 	defer s.close()
 
@@ -73,7 +73,7 @@ func TestStreamDisableAutoReplay(t *testing.T) {
 func TestStreamMultipleSubscribers(t *testing.T) {
 	var subs []*Subscriber
 
-	s := newStream(1024, true)
+	s := newStream(1024, true, false)
 	s.run()
 
 	for i := 0; i < 10; i++ {

--- a/subscriber.go
+++ b/subscriber.go
@@ -15,5 +15,7 @@ type Subscriber struct {
 // Close will let the stream know that the clients connection has terminated
 func (s *Subscriber) close() {
 	s.quit <- s
-	<-s.removed
+	if s.removed != nil {
+		<-s.removed
+	}
 }

--- a/subscriber.go
+++ b/subscriber.go
@@ -9,9 +9,11 @@ type Subscriber struct {
 	eventid    int
 	quit       chan *Subscriber
 	connection chan *Event
+	removed    chan struct{}
 }
 
 // Close will let the stream know that the clients connection has terminated
 func (s *Subscriber) close() {
 	s.quit <- s
+	<-s.removed
 }


### PR DESCRIPTION
@purehyperbole, @codewinch I think this is needed to cleanup a bit especially if there are many streams for short periods, something like `/events?stream=<eventIDEachTimeDifferent>`.

But the new test sometimes is green sometimes not. What do you think?

It always turns green if I add this line:

```go
time.Sleep(1*time.Second)
```

after the line:

```go
sub.close()
```

in `http.go`.

But I don't like `time.Sleep()` in code.

Can we better "wait" for `sub.close()` to finish?