### PR TITLE
detect if data is a comment

### DIFF
--- a/http.go
+++ b/http.go
@@ -63,9 +63,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	flusher.Flush()
+
 	// Push events to client
 	for ev := range sub.connection {
-
 		// If the data buffer is an empty string abort.
 		if len(ev.Data) == 0 {
 			break
@@ -84,7 +84,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				fmt.Fprintf(w, "data: %s\n", sd[i])
 			}
 		} else {
-			fmt.Fprintf(w, "data: %s\n", ev.Data)
+			if bytes.HasPrefix(ev.Data, []byte(":")) {
+				fmt.Fprintf(w, "%s\n", ev.Data)
+			} else {
+				fmt.Fprintf(w, "data: %s\n", ev.Data)
+			}
 		}
 
 		if len(ev.Event) > 0 {


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format we can send a message as a comment if it starts with ":".

> Note: The comment line can be used to prevent connections from timing out; a server can send a comment periodically to keep the connection alive.