### PR TITLE
allow configuration of max buffer client size

### DIFF
--- a/event.go
+++ b/event.go
@@ -29,8 +29,10 @@ type EventStreamReader struct {
 }
 
 // NewEventStreamReader creates an instance of EventStreamReader.
-func NewEventStreamReader(eventStream io.Reader) *EventStreamReader {
+func NewEventStreamReader(eventStream io.Reader, maxBufferSize int) *EventStreamReader {
 	scanner := bufio.NewScanner(eventStream)
+	scanner.Buffer(make([]byte, 4096), maxBufferSize)
+
 	split := func(data []byte, atEOF bool) (int, []byte, error) {
 		if atEOF && len(data) == 0 {
 			return 0, nil, nil


### PR DESCRIPTION
- [x] Allow configuration of bufio scanner maximum buffer size for clients receiving large events

Note: Defaults to the normal bufio values.