### PR TITLE
Add w.WriteHeader() call before first Flush()

### DIFF
--- a/http.go
+++ b/http.go
@@ -69,6 +69,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
+	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
 
 	// Push events to client


### PR DESCRIPTION
This change makes the SSE server work with chi's Compress middleware. Compress uses response headers to determine if the response body is [compressible](https://github.com/go-chi/chi/blob/0316d5a1df8598eceb137f5f77945be56810b564/middleware/compress.go#L281), so the headers should be written out before flushing. Hope this change can save other users a couple of hours of digging.