### PR TITLE
fix context handling SubscribeWithContext

### DIFF
--- a/client.go
+++ b/client.go
@@ -103,6 +103,8 @@ func (c *Client) SubscribeWithContext(ctx context.Context, stream string, handle
 				return err
 			case msg := <-eventChan:
 				handler(msg)
+			case <- ctx.Done():
+				return ctx.Err()
 			}
 		}
 	}


### PR DESCRIPTION
Fix bug where functions that call `SubscribeWithContext()` can end up in an endless loop waiting for input from `errorChan` or `eventChan` while context is done.