### PR TITLE
feature(server) : add callback function for register and un-register

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -18,7 +18,7 @@ import (
 	"gopkg.in/cenkalti/backoff.v1"
 )
 
-var url string
+var urlPath string
 var srv *Server
 var server *httptest.Server
 
@@ -55,7 +55,7 @@ func newServer() *Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/events", srv.ServeHTTP)
 	server = httptest.NewServer(mux)
-	url = server.URL + "/events"
+	urlPath = server.URL + "/events"
 
 	srv.CreateStream("test")
 
@@ -71,7 +71,7 @@ func newServer401() *Server {
 	})
 
 	server = httptest.NewServer(mux)
-	url = server.URL + "/events"
+	urlPath = server.URL + "/events"
 
 	srv.CreateStream("test")
 
@@ -105,7 +105,7 @@ func TestClientSubscribe(t *testing.T) {
 	setup(false)
 	defer cleanup()
 
-	c := NewClient(url)
+	c := NewClient(urlPath)
 
 	events := make(chan *Event)
 	var cErr error
@@ -131,7 +131,7 @@ func TestClientSubscribeMultiline(t *testing.T) {
 	setupMultiline()
 	defer cleanup()
 
-	c := NewClient(url)
+	c := NewClient(urlPath)
 
 	events := make(chan *Event)
 	var cErr error
@@ -158,7 +158,7 @@ func TestClientChanSubscribeEmptyMessage(t *testing.T) {
 	setup(true)
 	defer cleanup()
 
-	c := NewClient(url)
+	c := NewClient(urlPath)
 
 	events := make(chan *Event)
 	err := c.SubscribeChan("test", events)
@@ -174,7 +174,7 @@ func TestClientChanSubscribe(t *testing.T) {
 	setup(false)
 	defer cleanup()
 
-	c := NewClient(url)
+	c := NewClient(urlPath)
 
 	events := make(chan *Event)
 	err := c.SubscribeChan("test", events)
@@ -196,7 +196,7 @@ func TestClientOnDisconnect(t *testing.T) {
 	setup(false)
 	defer cleanup()
 
-	c := NewClient(url)
+	c := NewClient(urlPath)
 
 	called := make(chan struct{})
 	c.OnDisconnect(func(client *Client) {
@@ -215,7 +215,7 @@ func TestClientChanReconnect(t *testing.T) {
 	setup(false)
 	defer cleanup()
 
-	c := NewClient(url)
+	c := NewClient(urlPath)
 
 	events := make(chan *Event)
 	err := c.SubscribeChan("test", events)
@@ -241,7 +241,7 @@ func TestClientUnsubscribe(t *testing.T) {
 	setup(false)
 	defer cleanup()
 
-	c := NewClient(url)
+	c := NewClient(urlPath)
 
 	events := make(chan *Event)
 	err := c.SubscribeChan("test", events)
@@ -258,7 +258,7 @@ func TestClientUnsubscribeNonBlock(t *testing.T) {
 	setupCount(false, count)
 	defer cleanup()
 
-	c := NewClient(url)
+	c := NewClient(urlPath)
 
 	events := make(chan *Event)
 	err := c.SubscribeChan("test", events)
@@ -286,7 +286,7 @@ func TestClientUnsubscribe401(t *testing.T) {
 	srv = newServer401()
 	defer cleanup()
 
-	c := NewClient(url)
+	c := NewClient(urlPath)
 
 	// limit retries to 3
 	c.ReconnectStrategy = backoff.WithMaxTries(
@@ -306,7 +306,7 @@ func TestClientLargeData(t *testing.T) {
 	srv = newServer()
 	defer cleanup()
 
-	c := NewClient(url, ClientMaxBufferSize(1<<19))
+	c := NewClient(urlPath, ClientMaxBufferSize(1<<19))
 
 	// limit retries to 3
 	c.ReconnectStrategy = backoff.WithMaxTries(

--- a/http.go
+++ b/http.go
@@ -57,7 +57,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create the stream subscriber
-	sub := stream.addSubscriber(eventid)
+	sub := stream.addSubscriber(eventid, r.URL)
 
 	go func() {
 		<-r.Context().Done()

--- a/server.go
+++ b/server.go
@@ -32,8 +32,8 @@ type Server struct {
 	AutoReplay bool
 
 	// Specifies the function to run when client register or un-register
-	OnRegister   func()
-	OnUnRegister func()
+	OnRegister   func(str *Stream)
+	OnUnRegister func(str *Stream)
 }
 
 // New will create a server and setup defaults
@@ -48,7 +48,7 @@ func New() *Server {
 }
 
 // NewWithCallback will create a server and setup defaults with callback function
-func NewWithCallback(onRegister, onUnRegister func()) *Server {
+func NewWithCallback(onRegister, onUnRegister func(str *Stream)) *Server {
 	return &Server{
 		BufferSize:   DefaultBufferSize,
 		AutoStream:   false,
@@ -80,7 +80,7 @@ func (s *Server) CreateStream(id string) *Stream {
 		return s.Streams[id]
 	}
 
-	str := newStream(s.BufferSize, s.AutoReplay, s.AutoStream, s.OnRegister, s.OnUnRegister)
+	str := newStream(id, s.BufferSize, s.AutoReplay, s.AutoStream, s.OnRegister, s.OnUnRegister)
 	str.run()
 
 	s.Streams[id] = str

--- a/server.go
+++ b/server.go
@@ -31,9 +31,9 @@ type Server struct {
 	// Enables automatic replay for each new subscriber that connects
 	AutoReplay bool
 
-	// Specifies the function to run when client register or un-register
-	OnRegister   func(str *Stream)
-	OnUnRegister func(str *Stream)
+	// Specifies the function to run when client subscribe or un-subscribe
+	OnSubscribe   func(streamID string, sub *Subscriber)
+	OnUnsubscribe func(streamID string, sub *Subscriber)
 }
 
 // New will create a server and setup defaults
@@ -48,15 +48,15 @@ func New() *Server {
 }
 
 // NewWithCallback will create a server and setup defaults with callback function
-func NewWithCallback(onRegister, onUnRegister func(str *Stream)) *Server {
+func NewWithCallback(onSubscribe, onUnsubscribe func(streamID string, sub *Subscriber)) *Server {
 	return &Server{
-		BufferSize:   DefaultBufferSize,
-		AutoStream:   false,
-		AutoReplay:   true,
-		Streams:      make(map[string]*Stream),
-		Headers:      map[string]string{},
-		OnRegister:   onRegister,
-		OnUnRegister: onUnRegister,
+		BufferSize:    DefaultBufferSize,
+		AutoStream:    false,
+		AutoReplay:    true,
+		Streams:       make(map[string]*Stream),
+		Headers:       map[string]string{},
+		OnSubscribe:   onSubscribe,
+		OnUnsubscribe: onUnsubscribe,
 	}
 }
 
@@ -80,7 +80,7 @@ func (s *Server) CreateStream(id string) *Stream {
 		return s.Streams[id]
 	}
 
-	str := newStream(id, s.BufferSize, s.AutoReplay, s.AutoStream, s.OnRegister, s.OnUnRegister)
+	str := newStream(id, s.BufferSize, s.AutoReplay, s.AutoStream, s.OnSubscribe, s.OnUnsubscribe)
 	str.run()
 
 	s.Streams[id] = str

--- a/server.go
+++ b/server.go
@@ -30,6 +30,10 @@ type Server struct {
 	AutoStream bool
 	// Enables automatic replay for each new subscriber that connects
 	AutoReplay bool
+
+	// Specifies the function to run when client register or un-register
+	OnRegister   func()
+	OnUnRegister func()
 }
 
 // New will create a server and setup defaults
@@ -40,6 +44,19 @@ func New() *Server {
 		AutoReplay: true,
 		Streams:    make(map[string]*Stream),
 		Headers:    map[string]string{},
+	}
+}
+
+// NewWithCallback will create a server and setup defaults with callback function
+func NewWithCallback(onRegister, onUnRegister func()) *Server {
+	return &Server{
+		BufferSize:   DefaultBufferSize,
+		AutoStream:   false,
+		AutoReplay:   true,
+		Streams:      make(map[string]*Stream),
+		Headers:      map[string]string{},
+		OnRegister:   onRegister,
+		OnUnRegister: onUnRegister,
 	}
 }
 
@@ -63,7 +80,7 @@ func (s *Server) CreateStream(id string) *Stream {
 		return s.Streams[id]
 	}
 
-	str := newStream(s.BufferSize, s.AutoReplay, s.AutoStream)
+	str := newStream(s.BufferSize, s.AutoReplay, s.AutoStream, s.OnRegister, s.OnUnRegister)
 	str.run()
 
 	s.Streams[id] = str

--- a/server_test.go
+++ b/server_test.go
@@ -46,13 +46,13 @@ func TestServerCreateStream(t *testing.T) {
 }
 
 func TestServerWithCallback(t *testing.T) {
-	funcA := func(s *Stream) {}
-	funcB := func(s *Stream) {}
+	funcA := func(string, *Subscriber) {}
+	funcB := func(string, *Subscriber) {}
 
 	s := NewWithCallback(funcA, funcB)
 	defer s.Close()
-	assert.NotNil(t, s.OnRegister)
-	assert.NotNil(t, s.OnUnRegister)
+	assert.NotNil(t, s.OnSubscribe)
+	assert.NotNil(t, s.OnUnsubscribe)
 }
 
 func TestServerCreateExistingStream(t *testing.T) {
@@ -94,7 +94,7 @@ func TestServerExistingStreamPublish(t *testing.T) {
 
 	s.CreateStream("test")
 	stream := s.getStream("test")
-	sub := stream.addSubscriber(0)
+	sub := stream.addSubscriber(0, nil)
 
 	s.Publish("test", &Event{Data: []byte("test")})
 

--- a/server_test.go
+++ b/server_test.go
@@ -45,6 +45,16 @@ func TestServerCreateStream(t *testing.T) {
 	assert.NotNil(t, s.getStream("test"))
 }
 
+func TestServerWithCallback(t *testing.T) {
+	funcA := func() {}
+	funcB := func() {}
+
+	s := NewWithCallback(funcA, funcB)
+	defer s.Close()
+	assert.NotNil(t, s.OnRegister)
+	assert.NotNil(t, s.OnUnRegister)
+}
+
 func TestServerCreateExistingStream(t *testing.T) {
 	s := New()
 	defer s.Close()

--- a/server_test.go
+++ b/server_test.go
@@ -46,8 +46,8 @@ func TestServerCreateStream(t *testing.T) {
 }
 
 func TestServerWithCallback(t *testing.T) {
-	funcA := func() {}
-	funcB := func() {}
+	funcA := func(s *Stream) {}
+	funcB := func(s *Stream) {}
 
 	s := NewWithCallback(funcA, funcB)
 	defer s.Close()

--- a/stream_test.go
+++ b/stream_test.go
@@ -16,7 +16,7 @@ import (
 // Maybe fix this in the future so we can test with -race enabled
 
 func TestStreamAddSubscriber(t *testing.T) {
-	s := newStream(1024, true, false, nil, nil)
+	s := newStream("test", 1024, true, false, nil, nil)
 	s.run()
 	defer s.close()
 
@@ -34,7 +34,7 @@ func TestStreamAddSubscriber(t *testing.T) {
 }
 
 func TestStreamRemoveSubscriber(t *testing.T) {
-	s := newStream(1024, true, false, nil, nil)
+	s := newStream("test", 1024, true, false, nil, nil)
 	s.run()
 	defer s.close()
 
@@ -46,7 +46,7 @@ func TestStreamRemoveSubscriber(t *testing.T) {
 }
 
 func TestStreamSubscriberClose(t *testing.T) {
-	s := newStream(1024, true, false, nil, nil)
+	s := newStream("test", 1024, true, false, nil, nil)
 	s.run()
 	defer s.close()
 
@@ -58,7 +58,7 @@ func TestStreamSubscriberClose(t *testing.T) {
 }
 
 func TestStreamDisableAutoReplay(t *testing.T) {
-	s := newStream(1024, true, false, nil, nil)
+	s := newStream("test", 1024, true, false, nil, nil)
 	s.run()
 	defer s.close()
 
@@ -73,7 +73,7 @@ func TestStreamDisableAutoReplay(t *testing.T) {
 func TestStreamMultipleSubscribers(t *testing.T) {
 	var subs []*Subscriber
 
-	s := newStream(1024, true, false, nil, nil)
+	s := newStream("test", 1024, true, false, nil, nil)
 	s.run()
 
 	for i := 0; i < 10; i++ {

--- a/stream_test.go
+++ b/stream_test.go
@@ -16,7 +16,7 @@ import (
 // Maybe fix this in the future so we can test with -race enabled
 
 func TestStreamAddSubscriber(t *testing.T) {
-	s := newStream(1024, true, false)
+	s := newStream(1024, true, false, nil, nil)
 	s.run()
 	defer s.close()
 
@@ -34,7 +34,7 @@ func TestStreamAddSubscriber(t *testing.T) {
 }
 
 func TestStreamRemoveSubscriber(t *testing.T) {
-	s := newStream(1024, true, false)
+	s := newStream(1024, true, false, nil, nil)
 	s.run()
 	defer s.close()
 
@@ -46,7 +46,7 @@ func TestStreamRemoveSubscriber(t *testing.T) {
 }
 
 func TestStreamSubscriberClose(t *testing.T) {
-	s := newStream(1024, true, false)
+	s := newStream(1024, true, false, nil, nil)
 	s.run()
 	defer s.close()
 
@@ -58,7 +58,7 @@ func TestStreamSubscriberClose(t *testing.T) {
 }
 
 func TestStreamDisableAutoReplay(t *testing.T) {
-	s := newStream(1024, true, false)
+	s := newStream(1024, true, false, nil, nil)
 	s.run()
 	defer s.close()
 
@@ -73,7 +73,7 @@ func TestStreamDisableAutoReplay(t *testing.T) {
 func TestStreamMultipleSubscribers(t *testing.T) {
 	var subs []*Subscriber
 
-	s := newStream(1024, true, false)
+	s := newStream(1024, true, false, nil, nil)
 	s.run()
 
 	for i := 0; i < 10; i++ {

--- a/stream_test.go
+++ b/stream_test.go
@@ -21,7 +21,7 @@ func TestStreamAddSubscriber(t *testing.T) {
 	defer s.close()
 
 	s.event <- &Event{Data: []byte("test")}
-	sub := s.addSubscriber(0)
+	sub := s.addSubscriber(0, nil)
 
 	assert.Equal(t, 1, s.getSubscriberCount())
 
@@ -38,7 +38,7 @@ func TestStreamRemoveSubscriber(t *testing.T) {
 	s.run()
 	defer s.close()
 
-	s.addSubscriber(0)
+	s.addSubscriber(0, nil)
 	time.Sleep(time.Millisecond * 100)
 	s.removeSubscriber(0)
 
@@ -50,7 +50,7 @@ func TestStreamSubscriberClose(t *testing.T) {
 	s.run()
 	defer s.close()
 
-	sub := s.addSubscriber(0)
+	sub := s.addSubscriber(0, nil)
 	sub.close()
 	time.Sleep(time.Millisecond * 100)
 
@@ -65,7 +65,7 @@ func TestStreamDisableAutoReplay(t *testing.T) {
 	s.AutoReplay = false
 	s.event <- &Event{Data: []byte("test")}
 	time.Sleep(time.Millisecond * 100)
-	sub := s.addSubscriber(0)
+	sub := s.addSubscriber(0, nil)
 
 	assert.Equal(t, 0, len(sub.connection))
 }
@@ -77,7 +77,7 @@ func TestStreamMultipleSubscribers(t *testing.T) {
 	s.run()
 
 	for i := 0; i < 10; i++ {
-		subs = append(subs, s.addSubscriber(0))
+		subs = append(subs, s.addSubscriber(0, nil))
 	}
 
 	// Wait for all subscribers to be added

--- a/subscriber.go
+++ b/subscriber.go
@@ -4,12 +4,15 @@
 
 package sse
 
+import "net/url"
+
 // Subscriber ...
 type Subscriber struct {
 	quit       chan *Subscriber
 	connection chan *Event
 	removed    chan struct{}
 	eventid    int
+	URL        *url.URL
 }
 
 // Close will let the stream know that the clients connection has terminated


### PR DESCRIPTION
this change makes callback function to support when client register or un-register SSE

issue : #132 

![Screen Recording 2565-05-08 at 03 05 54](https://user-images.githubusercontent.com/34530268/167270389-de6c4cb6-533c-4311-ac3e-78429688823e.gif)


**example server**
```go	
package main

import (
	"fmt"
	"net/http"
	"time"

	"github.com/r3labs/sse/v2"
)

func main() {
	c := make(map[string]int32)

	onRegister := func(str *sse.Stream) {
		c[str.ID]++
		fmt.Printf("\U0001F7E2 [channel : %s] client is registered (%d registered)\n", str.ID, c[str.ID])
	}

	onUnRegister := func(str *sse.Stream) {
		c[str.ID]--
		fmt.Printf("🔴 [channel : %s] client is registered (%d registered)\n", str.ID, c[str.ID])
	}

	server := sse.NewWithCallback(onRegister, onUnRegister)
	server.AutoStream = true
	server.AutoReplay = false

	// Create a new Mux and set the handler
	mux := http.NewServeMux()
	mux.HandleFunc("/events", server.ServeHTTP)

	go func() {
		for {
			time.Sleep(2 * time.Second)
			server.Publish("ch1", &sse.Event{
				Data: []byte("this is channel 1"),
			})
			server.Publish("ch2", &sse.Event{
				Data: []byte("this is channel 2"),
			})
		}
	}()

	http.ListenAndServe(":8080", mux)
}
```

**example client**
```go	
package main

import (
	"flag"
	"fmt"
	"log"

	"github.com/r3labs/sse/v2"
)

func main() {
	channelPtr := flag.String("channel", "test", "channel id")
	flag.Parse()
	c := sse.NewClient("http://localhost:8080/events")

	err := c.Subscribe(*channelPtr, func(msg *sse.Event) {
		fmt.Println(string(msg.Data))
	})
	if err != nil {
		log.Fatalln(err.Error())
	}
}

```