### PR TITLE
Fix bug, goroutine leak in the functions SubscribeWithContext()

### DIFF
--- a/client.go
+++ b/client.go
@@ -103,8 +103,6 @@ func (c *Client) SubscribeWithContext(ctx context.Context, stream string, handle
 				return err
 			case msg := <-eventChan:
 				handler(msg)
-			case <-ctx.Done():
-				return ctx.Err()
 			}
 		}
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -5,10 +5,12 @@
 package sse
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"testing"
 	"time"
 
@@ -377,4 +379,27 @@ func TestTrimHeader(t *testing.T) {
 		got := trimHeader(len(headerData), tc.input)
 		require.Equal(t, tc.want, got)
 	}
+}
+
+func TestSubscribeWithContextDone(t *testing.T) {
+	setup(false)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var n1 = runtime.NumGoroutine()
+
+	c := NewClient(urlPath)
+
+	for i := 0; i < 10; i++ {
+		go c.SubscribeWithContext(ctx, "test", func(msg *Event) {})
+	}
+
+	time.Sleep(1 * time.Second)
+	cancel()
+
+	time.Sleep(1 * time.Second)
+	var n2 = runtime.NumGoroutine()
+
+	assert.Equal(t, n1, n2)
 }


### PR DESCRIPTION
select ctx.Done() in operation() will cause operation() return before c.readLoop(), 
the unbuffered channel name "erChan" will block c.readLoop() after io.EOF,
c.readLoop() will never return.
because of the error return from operation() is not nil,
the backoff.RetryNotify() will never return

![20221110135327](https://user-images.githubusercontent.com/37259540/201011849-42dd0115-db77-4392-b402-15f3ae43a7ab.png)
