### PR TITLE
Optimize locking

### DIFF
--- a/http_test.go
+++ b/http_test.go
@@ -102,7 +102,7 @@ func TestHTTPStreamHandlerEventID(t *testing.T) {
 	time.Sleep(time.Millisecond * 100)
 
 	c := NewClient(server.URL + "/events")
-	c.EventID = "2"
+	c.LastEventID.Store([]byte("2"))
 
 	events := make(chan *Event)
 	var cErr error

--- a/stream.go
+++ b/stream.go
@@ -6,6 +6,7 @@ package sse
 
 import (
 	"net/url"
+	"sync"
 	"sync/atomic"
 )
 
@@ -14,6 +15,7 @@ type Stream struct {
 	ID              string
 	event           chan *Event
 	quit            chan struct{}
+	quitOnce        sync.Once
 	register        chan *Subscriber
 	deregister      chan *Subscriber
 	subscribers     []*Subscriber
@@ -87,7 +89,9 @@ func (str *Stream) run() {
 }
 
 func (str *Stream) close() {
-	str.quit <- struct{}{}
+	str.quitOnce.Do(func() {
+		close(str.quit)
+	})
 }
 
 func (str *Stream) getSubIndex(sub *Subscriber) int {

--- a/stream_test.go
+++ b/stream_test.go
@@ -38,9 +38,10 @@ func TestStreamRemoveSubscriber(t *testing.T) {
 	s.run()
 	defer s.close()
 
-	s.addSubscriber(0, nil)
+	sub := s.addSubscriber(0, nil)
 	time.Sleep(time.Millisecond * 100)
-	s.removeSubscriber(0)
+	s.deregister <- sub
+	time.Sleep(time.Millisecond * 100)
 
 	assert.Equal(t, 0, s.getSubscriberCount())
 }


### PR DESCRIPTION
Changes:
1. Optimized locking so publishing doesn't prevent closing, for example. I found this in another of my branch, which tried to use `ResponseController` newly introduced in Go 1.20 to detect disconnected clients (via the error returned by the new `Flush()` method). That ended up not working well due to TCP retransmission so I abandoned the work, but thinking the optimization should be useful.
2. Fixed two race conditions found with `go test -race`.

No tests since I'm not quite familiar with the codebase yet, but if anyone can point me in which way I can add them, I'd be happy to do.

I also noticed that this test frequently failed on my macOS even in `master`. I can have a look too if that's desirable.
```
=== RUN   TestSubscribeWithContextDone
    client_test.go:423:
        	Error Trace:	client_test.go:423
        	Error:      	Not equal:
        	            	expected: 28
        	            	actual  : 27
        	Test:       	TestSubscribeWithContextDone
```