### PR TITLE
client: reconnect after an EOF

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,7 +10,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -213,10 +212,6 @@ func (c *Client) readLoop(reader *EventStreamReader, outCh chan *Event, erChan c
 		// Read each new line and process the type of event
 		event, err := reader.ReadEvent()
 		if err != nil {
-			if err == io.EOF {
-				erChan <- nil
-				return
-			}
 			// run user specified disconnect function
 			if c.disconnectcb != nil {
 				c.Connected = false

--- a/client_test.go
+++ b/client_test.go
@@ -34,12 +34,11 @@ var mldata = `{
 	]
 }`
 
-func setup(empty bool) *Server {
+func setup(empty bool) {
 	// New Server
 	srv = newServer()
 	// Send almost-continuous string of events to the client
 	go publishMsgs(srv, empty, 100000000)
-	return srv
 }
 
 func setupMultiline() {
@@ -261,7 +260,7 @@ func TestClientChanReconnect(t *testing.T) {
 }
 
 func TestClientChanReconnectOnEOF(t *testing.T) {
-	srv := setup(false)
+	setup(false)
 	defer cleanup()
 	streamID := "test"
 


### PR DESCRIPTION
Closes #147 

Removes the special case for EOF errors, so that a client will reconnect when the stream is closed with an EOF.

Edit: this is almost a duplicate of #145 / #75 - although that keeps the old behavior by default, with an `AutoReconnect` flag. I am not sure why the default behavior is desirable (the conversation could happen in any of those issues). (So if this PR is preferred, it closes #75 and closes #145)