### PR TITLE
Reset the backoff time on successful connection

### DIFF
--- a/client.go
+++ b/client.go
@@ -97,6 +97,11 @@ func (c *Client) SubscribeWithContext(ctx context.Context, stream string, handle
 		}
 		defer resp.Body.Close()
 
+		// Successful connection: reset the backoff time.
+		if c.ReconnectStrategy != nil {
+			c.ReconnectStrategy.Reset()
+		}
+
 		reader := NewEventStreamReader(resp.Body, c.maxBufferSize)
 		eventChan, errorChan := c.startReadLoop(reader)
 


### PR DESCRIPTION
The backoff should increase relative to the last error, not indefinitely.