### PR TITLE
refactor: better error check(that handle wrap), use std constants, typos and fields alignement

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ make test
 
 #### Example Server
 
-There are two parts of the server. It is comprised of the message scheduler and a http handler function.
+There are two parts of the server. It comprises the message scheduler and a http handler function.
 The messaging system is started when running:
 
 ```go
@@ -42,8 +42,8 @@ func main() {
 }
 ```
 
-This creates a new stream inside of the scheduler. Seeing as there are no consumers, publishing a message to this channel will do nothing.
-Clients can connect to this stream once the http handler is started by specifying _stream_ as a url parameter, like so:
+This creates a new stream inside the scheduler. Seeing as there are no consumers, publishing a message to this channel will do nothing.
+Clients can connect to this stream once the http handler is started by specifying _stream_ as an url parameter, like so:
 
 ```
 http://server/events?stream=messages
@@ -103,7 +103,7 @@ func main() {
 
 #### Example Client
 
-The client exposes a way to connect to an SSE server. The client can also handle multiple events under the same url.
+The client exposes a way to connect to a SSE server. The client can also handle multiple events under the same url.
 
 To create a new client:
 
@@ -141,7 +141,7 @@ func main() {
 
 #### HTTP client parameters
 
-To add additional parameters to the http client, such as disabling ssl verification for self signed certs, you can override the http client or update its options:
+To add additional parameters to the http client, such as disabling ssl verification for self-signed certs, you can override the http client or update its options:
 
 ```go
 func main() {

--- a/client.go
+++ b/client.go
@@ -91,7 +91,7 @@ func (c *Client) SubscribeWithContext(ctx context.Context, stream string, handle
 			if err != nil {
 				return err
 			}
-		} else if resp.StatusCode != 200 {
+		} else if resp.StatusCode != http.StatusOK {
 			resp.Body.Close()
 			return fmt.Errorf("could not connect to stream: %s", http.StatusText(resp.StatusCode))
 		}
@@ -143,7 +143,7 @@ func (c *Client) SubscribeChanWithContext(ctx context.Context, stream string, ch
 			if err != nil {
 				return err
 			}
-		} else if resp.StatusCode != 200 {
+		} else if resp.StatusCode != http.StatusOK {
 			resp.Body.Close()
 			return fmt.Errorf("could not connect to stream: %s", http.StatusText(resp.StatusCode))
 		}
@@ -213,7 +213,7 @@ func (c *Client) readLoop(reader *EventStreamReader, outCh chan *Event, erChan c
 		// Read each new line and process the type of event
 		event, err := reader.ReadEvent()
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				erChan <- nil
 				return
 			}
@@ -248,12 +248,12 @@ func (c *Client) readLoop(reader *EventStreamReader, outCh chan *Event, erChan c
 	}
 }
 
-// SubscribeRaw to an sse endpoint
+// SubscribeRaw to a sse endpoint
 func (c *Client) SubscribeRaw(handler func(msg *Event)) error {
 	return c.Subscribe("", handler)
 }
 
-// SubscribeRawWithContext to an sse endpoint with context
+// SubscribeRawWithContext to a sse endpoint with context
 func (c *Client) SubscribeRawWithContext(ctx context.Context, handler func(msg *Event)) error {
 	return c.SubscribeWithContext(ctx, "", handler)
 }
@@ -289,7 +289,7 @@ func (c *Client) OnConnect(fn ConnCallback) {
 }
 
 func (c *Client) request(ctx context.Context, stream string) (*http.Response, error) {
-	req, err := http.NewRequest("GET", c.URL, nil)
+	req, err := http.NewRequest(http.MethodGet, c.URL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -334,7 +334,7 @@ func (c *Client) processEvent(msg []byte) (event *Event, err error) {
 			e.ID = append([]byte(nil), trimHeader(len(headerID), line)...)
 		case bytes.HasPrefix(line, headerData):
 			// The spec allows for multiple data fields per event, concatenated them with "\n".
-			e.Data = append(e.Data[:], append(trimHeader(len(headerData), line), byte('\n'))...)
+			e.Data = append(e.Data, append(trimHeader(len(headerData), line), byte('\n'))...)
 		// The spec says that a line that simply contains the string "data" should be treated as a data field with an empty body.
 		case bytes.Equal(line, bytes.TrimSuffix(headerData, []byte(":"))):
 			e.Data = append(e.Data, byte('\n'))
@@ -355,7 +355,7 @@ func (c *Client) processEvent(msg []byte) (event *Event, err error) {
 
 		n, err := base64.StdEncoding.Decode(buf, e.Data)
 		if err != nil {
-			err = fmt.Errorf("failed to decode event message: %s", err)
+			err = fmt.Errorf("failed to decode event message: %w", err)
 		}
 		e.Data = buf[:n]
 	}

--- a/client.go
+++ b/client.go
@@ -42,15 +42,15 @@ type ResponseValidator func(c *Client, resp *http.Response) error
 type Client struct {
 	Retry             time.Time
 	ReconnectStrategy backoff.BackOff
-	disconnectcb      ConnCallback
-	connectedcb       ConnCallback
+	LastEventID       atomic.Value // []byte
+	ReconnectNotify   backoff.Notify
 	subscribed        map[chan *Event]chan struct{}
 	Headers           map[string]string
-	ReconnectNotify   backoff.Notify
+	connectedcb       ConnCallback
 	ResponseValidator ResponseValidator
 	Connection        *http.Client
+	disconnectcb      ConnCallback
 	URL               string
-	LastEventID       atomic.Value // []byte
 	maxBufferSize     int
 	mu                sync.Mutex
 	EncodingBase64    bool

--- a/client_test.go
+++ b/client_test.go
@@ -16,13 +16,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	"gopkg.in/cenkalti/backoff.v1"
 )
 
-var urlPath string
-var srv *Server
-var server *httptest.Server
+var (
+	urlPath string
+	srv     *Server
+	server  *httptest.Server
+)
 
 var mldata = `{
 	"key": "value",
@@ -406,7 +407,7 @@ func TestSubscribeWithContextDone(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	var n1 = runtime.NumGoroutine()
+	n1 := runtime.NumGoroutine()
 
 	c := NewClient(urlPath)
 
@@ -418,7 +419,7 @@ func TestSubscribeWithContextDone(t *testing.T) {
 	cancel()
 
 	time.Sleep(1 * time.Second)
-	var n2 = runtime.NumGoroutine()
+	n2 := runtime.NumGoroutine()
 
 	assert.Equal(t, n1, n2)
 }

--- a/event.go
+++ b/event.go
@@ -8,11 +8,12 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"time"
 )
 
-// Event holds all of the event source fields
+// Event holds all the event source fields
 type Event struct {
 	timestamp time.Time
 	ID        []byte
@@ -46,7 +47,7 @@ func NewEventStreamReader(eventStream io.Reader, maxBufferSize int) *EventStream
 		if i, nlen := containsDoubleNewline(data); i >= 0 {
 			return i + nlen, data[0:i], nil
 		}
-		// If we're at EOF, we have all of the data.
+		// If we're at EOF, we have all the data.
 		if atEOF {
 			return len(data), data, nil
 		}
@@ -105,7 +106,7 @@ func (e *EventStreamReader) ReadEvent() ([]byte, error) {
 		return event, nil
 	}
 	if err := e.scanner.Err(); err != nil {
-		if err == context.Canceled {
+		if errors.Is(err, context.Canceled) {
 			return nil, io.EOF
 		}
 		return nil, err

--- a/http.go
+++ b/http.go
@@ -79,7 +79,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 
-		// if the event has expired, dont send it
+		// if the event has expired, don't send it
 		if s.EventTTL != 0 && time.Now().After(ev.timestamp.Add(s.EventTTL)) {
 			continue
 		}

--- a/server.go
+++ b/server.go
@@ -62,7 +62,7 @@ func NewWithCallback(onSubscribe, onUnsubscribe func(streamID string, sub *Subsc
 	}
 }
 
-// Close shuts down the server, closes all of the streams and connections
+// Close shuts down the server, closes all the streams and connections
 func (s *Server) Close() {
 	s.muStreams.Lock()
 	defer s.muStreams.Unlock()
@@ -106,7 +106,7 @@ func (s *Server) StreamExists(id string) bool {
 	return s.getStream(id) != nil
 }
 
-// Publish sends a mesage to every client in a streamID.
+// Publish sends a message to every client in a streamID.
 // If the stream's buffer is full, it blocks until the message is sent out to
 // all subscribers (but not necessarily arrived the clients), or when the
 // stream is closed.

--- a/server.go
+++ b/server.go
@@ -17,10 +17,15 @@ const DefaultBufferSize = 1024
 type Server struct {
 	// Extra headers adding to the HTTP response to each client
 	Headers map[string]string
+	// Specifies the function to run when client subscribe or un-subscribe
+	OnSubscribe   func(streamID string, sub *Subscriber)
+	OnUnsubscribe func(streamID string, sub *Subscriber)
+	streams       map[string]*Stream
 	// Sets a ttl that prevents old events from being transmitted
 	EventTTL time.Duration
 	// Specifies the size of the message buffer for each stream
 	BufferSize int
+	muStreams  sync.RWMutex
 	// Encodes all data as base64
 	EncodeBase64 bool
 	// Splits an events data into multiple data: entries
@@ -29,13 +34,6 @@ type Server struct {
 	AutoStream bool
 	// Enables automatic replay for each new subscriber that connects
 	AutoReplay bool
-
-	// Specifies the function to run when client subscribe or un-subscribe
-	OnSubscribe   func(streamID string, sub *Subscriber)
-	OnUnsubscribe func(streamID string, sub *Subscriber)
-
-	streams   map[string]*Stream
-	muStreams sync.RWMutex
 }
 
 // New will create a server and setup defaults

--- a/stream.go
+++ b/stream.go
@@ -12,22 +12,22 @@ import (
 
 // Stream ...
 type Stream struct {
+	// Specifies the function to run when client subscribe
+	OnSubscribe func(streamID string, sub *Subscriber)
+	event       chan *Event
+	quit        chan struct{}
+	register    chan *Subscriber
+	deregister  chan *Subscriber
+	// Specifies the function to run when client unsubscribe
+	OnUnsubscribe   func(streamID string, sub *Subscriber)
 	ID              string
-	event           chan *Event
-	quit            chan struct{}
-	quitOnce        sync.Once
-	register        chan *Subscriber
-	deregister      chan *Subscriber
 	subscribers     []*Subscriber
 	Eventlog        EventLog
+	quitOnce        sync.Once
 	subscriberCount int32
+	isAutoStream    bool
 	// Enables replaying of Eventlog to newly added subscribers
-	AutoReplay   bool
-	isAutoStream bool
-
-	// Specifies the function to run when client subscribe or un-subscribe
-	OnSubscribe   func(streamID string, sub *Subscriber)
-	OnUnsubscribe func(streamID string, sub *Subscriber)
+	AutoReplay bool
 }
 
 // newStream returns a new stream

--- a/stream.go
+++ b/stream.go
@@ -21,7 +21,7 @@ type Stream struct {
 	subscribers     []*Subscriber
 	Eventlog        EventLog
 	subscriberCount int32
-	// Enables replaying of eventlog to newly added subscribers
+	// Enables replaying of Eventlog to newly added subscribers
 	AutoReplay   bool
 	isAutoStream bool
 

--- a/subscriber.go
+++ b/subscriber.go
@@ -11,8 +11,8 @@ type Subscriber struct {
 	quit       chan *Subscriber
 	connection chan *Event
 	removed    chan struct{}
-	eventid    int
 	URL        *url.URL
+	eventid    int
 }
 
 // Close will let the stream know that the clients connection has terminated


### PR DESCRIPTION
- Correction of some small spelling mistakes.
- Better error wrapping print/check by using `%w` and `Error.is(...)`.
- Save 80 bytes in structs by aligning the padding fields.
- Using std constants.

```go
fieldalignment -fix .
/home/greyxor/Documents/Projects/sse/client.go:42:13: struct with 128 pointer bytes could be 120
/home/greyxor/Documents/Projects/sse/server.go:17:13: struct with 56 pointer bytes could be 32
/home/greyxor/Documents/Projects/sse/stream.go:14:13: struct with 136 pointer bytes could be 96
/home/greyxor/Documents/Projects/sse/subscriber.go:10:17: struct with 40 pointer bytes could be 32
```