### PR TITLE
feature: implement max log entries and replay per stream

### DIFF
--- a/event_log.go
+++ b/event_log.go
@@ -34,11 +34,14 @@ func (e *EventLog) Add(ev *Event) {
 	ev.ID = []byte(e.currentindex())
 	ev.timestamp = time.Now()
 
-	// if MaxEntries is greater than 0, and we are at max entries limit
-	// then reset the first log item and then pop it
-	if e.MaxEntries > 0 && len(e.Log) == e.MaxEntries {
-		e.Log[0] = nil
-		e.Log = e.Log[1:]
+	// if MaxEntries is set to greater than 0 (no limit) check entries
+	if e.MaxEntries > 0 {
+		// ifa we are at max entries limit
+		// then reset the first log item and then pop it
+		if len(e.Log) >= e.MaxEntries {
+			e.Log[0] = nil
+			e.Log = e.Log[1:]
+		}
 	}
 
 	e.Log = append(e.Log, ev)

--- a/event_log_test.go
+++ b/event_log_test.go
@@ -11,16 +11,27 @@ import (
 )
 
 func TestEventLog(t *testing.T) {
-	ev := make(EventLog, 0)
+	ev := newEventLog(0)
 	testEvent := &Event{Data: []byte("test")}
 
 	ev.Add(testEvent)
 	ev.Clear()
 
-	assert.Equal(t, 0, len(ev))
+	assert.Equal(t, 0, len(ev.Log))
 
 	ev.Add(testEvent)
 	ev.Add(testEvent)
 
-	assert.Equal(t, 2, len(ev))
+	assert.Equal(t, 2, len(ev.Log))
+}
+
+func TestEventLogMaxEntries(t *testing.T) {
+	ev := newEventLog(2)
+	testEvent := &Event{Data: []byte("test")}
+
+	ev.Add(testEvent)
+	ev.Add(testEvent)
+	ev.Add(testEvent)
+
+	assert.Equal(t, 2, len(ev.Log))
 }

--- a/event_log_test.go
+++ b/event_log_test.go
@@ -17,12 +17,12 @@ func TestEventLog(t *testing.T) {
 	ev.Add(testEvent)
 	ev.Clear()
 
-	assert.Equal(t, 0, len(ev.Log))
+	assert.Equal(t, 0, ev.Len())
 
 	ev.Add(testEvent)
 	ev.Add(testEvent)
 
-	assert.Equal(t, 2, len(ev.Log))
+	assert.Equal(t, 2, ev.Len())
 }
 
 func TestEventLogMaxEntries(t *testing.T) {
@@ -33,5 +33,5 @@ func TestEventLogMaxEntries(t *testing.T) {
 	ev.Add(testEvent)
 	ev.Add(testEvent)
 
-	assert.Equal(t, 2, len(ev.Log))
+	assert.Equal(t, 2, ev.Len())
 }

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,15 @@
 module github.com/r3labs/sse/v2
 
-go 1.13
+go 1.20
 
 require (
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/net v0.0.0-20191116160921-f9c825593386 // indirect
 	gopkg.in/cenkalti/backoff.v1 v1.1.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/net v0.0.0-20210610124326-52da8fb2a613 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,11 +5,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/net v0.0.0-20191116160921-f9c825593386 h1:ktbWvQrW08Txdxno1PiDpSxPXG6ndGsfnJjRRtkM0LQ=
-golang.org/x/net v0.0.0-20191116160921-f9c825593386/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/net v0.0.0-20210610124326-52da8fb2a613 h1:SqvqnUCcwFhyyRueFOEFTBaWeXYwK+CL/767809IlbQ=
+golang.org/x/net v0.0.0-20210610124326-52da8fb2a613/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 gopkg.in/cenkalti/backoff.v1 v1.1.0 h1:Arh75ttbsvlpVA7WtVpH4u9h6Zl46xuptxqLxPiSo4Y=
 gopkg.in/cenkalti/backoff.v1 v1.1.0/go.mod h1:J6Vskwqd+OMVJl8C33mmtxTBs2gyzfv7UDAkHu8BrjI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/server.go
+++ b/server.go
@@ -99,7 +99,7 @@ func (s *Server) CreateStreamWithOpts(id string, opts StreamOpts) *Stream {
 		return s.streams[id]
 	}
 
-	str := newStream(id, s.BufferSize, opts.MaxEntries, opts.AutoReplay, opts.AutoStream, opts.OnSubscribe, opts.OnUnsubscribe)
+	str := newStream(id, s.BufferSize, opts.MaxEntries, opts.AutoReplay, opts.AutoStream, s.OnSubscribe, s.OnUnsubscribe)
 	str.run()
 
 	s.streams[id] = str

--- a/server.go
+++ b/server.go
@@ -82,7 +82,24 @@ func (s *Server) CreateStream(id string) *Stream {
 		return s.streams[id]
 	}
 
-	str := newStream(id, s.BufferSize, s.AutoReplay, s.AutoStream, s.OnSubscribe, s.OnUnsubscribe)
+	str := newStream(id, s.BufferSize, 0, s.AutoReplay, s.AutoStream, s.OnSubscribe, s.OnUnsubscribe)
+	str.run()
+
+	s.streams[id] = str
+
+	return str
+}
+
+// CreateStreamWithOpts will create a new stream with options and register it
+func (s *Server) CreateStreamWithOpts(id string, opts StreamOpts) *Stream {
+	s.muStreams.Lock()
+	defer s.muStreams.Unlock()
+
+	if s.streams[id] != nil {
+		return s.streams[id]
+	}
+
+	str := newStream(id, s.BufferSize, opts.MaxEntries, opts.AutoReplay, opts.AutoStream, opts.OnSubscribe, opts.OnUnsubscribe)
 	str.run()
 
 	s.streams[id] = str

--- a/stream.go
+++ b/stream.go
@@ -37,10 +37,6 @@ type StreamOpts struct {
 	AutoStream bool
 	// Enables automatic replay for each new subscriber that connects
 	AutoReplay bool
-
-	// Specifies the function to run when client subscribe or un-subscribe
-	OnSubscribe   func(streamID string, sub *Subscriber)
-	OnUnsubscribe func(streamID string, sub *Subscriber)
 }
 
 // newStream returns a new stream

--- a/stream_test.go
+++ b/stream_test.go
@@ -16,7 +16,7 @@ import (
 // Maybe fix this in the future so we can test with -race enabled
 
 func TestStreamAddSubscriber(t *testing.T) {
-	s := newStream("test", 1024, true, false, nil, nil)
+	s := newStream("test", 1024, 0, true, false, nil, nil)
 	s.run()
 	defer s.close()
 
@@ -34,7 +34,7 @@ func TestStreamAddSubscriber(t *testing.T) {
 }
 
 func TestStreamRemoveSubscriber(t *testing.T) {
-	s := newStream("test", 1024, true, false, nil, nil)
+	s := newStream("test", 1024, 0, true, false, nil, nil)
 	s.run()
 	defer s.close()
 
@@ -47,7 +47,7 @@ func TestStreamRemoveSubscriber(t *testing.T) {
 }
 
 func TestStreamSubscriberClose(t *testing.T) {
-	s := newStream("test", 1024, true, false, nil, nil)
+	s := newStream("test", 1024, 0, true, false, nil, nil)
 	s.run()
 	defer s.close()
 
@@ -59,7 +59,7 @@ func TestStreamSubscriberClose(t *testing.T) {
 }
 
 func TestStreamDisableAutoReplay(t *testing.T) {
-	s := newStream("test", 1024, true, false, nil, nil)
+	s := newStream("test", 1024, 0, true, false, nil, nil)
 	s.run()
 	defer s.close()
 
@@ -74,7 +74,7 @@ func TestStreamDisableAutoReplay(t *testing.T) {
 func TestStreamMultipleSubscribers(t *testing.T) {
 	var subs []*Subscriber
 
-	s := newStream("test", 1024, true, false, nil, nil)
+	s := newStream("test", 1024, 0, true, false, nil, nil)
 	s.run()
 
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
Hi!

Been a happy user of this library for a couple of years and it works great! :smiley: 

Something I've wanted and needed for a while is the ability to set a limit on the amount of events the event log can store, and being able to set if it should replay per stream and not globally.

This PR implements a new log store using [container/list](https://pkg.go.dev/container/list) of the std library. 

Along with that it adds the new method `CreateStreamWithOpts(id string, opts StreamOpts)` which takes a `StreamOpts` config:

```go
type StreamOpts struct {
	// Max amount of log entries per stream
	MaxEntries int
	// Enables creation of a stream when a client connects
	AutoStream bool
	// Enables automatic replay for each new subscriber that connects
	AutoReplay bool
}
```

The benefits of a new method is the backwards compatibility is kept.

When `MaxEntries` is set to a value greater than 0 it will check the length on `Add`, then remove the log at the back, and insert the new log event.

* Added a new test case for the limit and all other passes
* Updated Go mod version and ran `go mod tidy` as well as updated `golang.org/x/net` which was vulnerable

Happy to take any feedback! And please let me know if this is something of interest at all. If not then I'll maintain a fork. :smile: 

If you think `container/list` is a bad idea, then we could possibly expose a `LogStorer` interface and have that configurable by the user and keep the old implementation as default.