### PR TITLE
always add timestamp to events

### DIFF
--- a/event_log.go
+++ b/event_log.go
@@ -6,7 +6,6 @@ package sse
 
 import (
 	"strconv"
-	"time"
 )
 
 // EventLog holds all of previous events
@@ -19,7 +18,6 @@ func (e *EventLog) Add(ev *Event) {
 	}
 
 	ev.ID = []byte(e.currentindex())
-	ev.timestamp = time.Now()
 	*e = append(*e, ev)
 }
 

--- a/stream.go
+++ b/stream.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 // Stream ...
@@ -71,6 +72,7 @@ func (str *Stream) run() {
 
 			// Publish event to subscribers
 			case event := <-str.event:
+				event.timestamp = time.Now()
 				if str.AutoReplay {
 					str.Eventlog.Add(event)
 				}


### PR DESCRIPTION
So EventTTL doesn't prevent sending events when AutoReplay is off