### PR TITLE
add request in Client struct to override the default request

### DIFF
--- a/client.go
+++ b/client.go
@@ -55,6 +55,7 @@ type Client struct {
 	mu                sync.Mutex
 	EncodingBase64    bool
 	Connected         bool
+	Request           *http.Request
 }
 
 // NewClient creates a new client
@@ -292,6 +293,10 @@ func (c *Client) request(ctx context.Context, stream string) (*http.Response, er
 	req, err := http.NewRequest("GET", c.URL, nil)
 	if err != nil {
 		return nil, err
+	}
+	// Override request with provided request
+	if c.Request != nil {
+		req = c.Request
 	}
 	req = req.WithContext(ctx)
 


### PR DESCRIPTION
I found multiple open issues regarding the client of sse and possibility to customize the request.

This is a very simple fix I came up with. Just added `*http.Request` to the client struct and user can set it like so:

```go
	client := sse.NewClient("some url", func(c *sse.Client) {
		c.Request = customRequest
	})
```

and change the request function so that if this request is set it would override the default behavior.