### PR TITLE
Fix flaky test TestSubscribeWithContextDone

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -10,7 +10,7 @@ import (
 	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
-	"runtime"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -400,25 +400,28 @@ func TestTrimHeader(t *testing.T) {
 	}
 }
 
+// Verify that cancelling the context really terminates the execution.
 func TestSubscribeWithContextDone(t *testing.T) {
 	setup(false)
 	defer cleanup()
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	var n1 = runtime.NumGoroutine()
+	var launched int32 = 10
+	var exited int32
 
 	c := NewClient(urlPath)
 
-	for i := 0; i < 10; i++ {
-		go c.SubscribeWithContext(ctx, "test", func(msg *Event) {})
+	for i := 0; i < int(launched); i++ {
+		go func() {
+			defer atomic.AddInt32(&exited, 1)
+			c.SubscribeWithContext(ctx, "test", func(msg *Event) {})
+		}()
 	}
 
-	time.Sleep(1 * time.Second)
+	time.Sleep(10 * time.Millisecond)
 	cancel()
 
-	time.Sleep(1 * time.Second)
-	var n2 = runtime.NumGoroutine()
-
-	assert.Equal(t, n1, n2)
+	time.Sleep(10 * time.Millisecond)
+	assert.Equal(t, launched, atomic.LoadInt32(&exited))
 }


### PR DESCRIPTION
Instead of comparing the number of goroutines which is inherently unreliable, we count the number of goroutines that exited using a defer statement, and an atomic counter.

By the way, the timer are reduced to 100ms as it is more than enough time to let the goroutines exit.

Closes: #186
