### PR TITLE
feat: add EvictSlowClients option to prevent slow subscribers blockin…

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -81,17 +81,18 @@ func (str *Stream) run() {
 					str.Eventlog.Add(event)
 				}
 				for i := len(str.subscribers) - 1; i >= 0; i-- {
-					select {
-					case str.subscribers[i].connection <- event:
-					default:
-						if str.EvictSlowClients {
-							// Subscriber buffer is full — client is stalled.
-							// Call removeSubscriber directly rather than close()
-							// because we are inside stream.run() and close() would
-							// deadlock by sending to the deregister channel that
-							// only this goroutine reads.
+					if str.EvictSlowClients {
+						// Non-blocking: if the buffer is full, evict the subscriber
+						// immediately rather than blocking the fan-out goroutine.
+						// removeSubscriber is used instead of close() to avoid
+						// deadlocking run() on its own deregister channel.
+						select {
+						case str.subscribers[i].connection <- event:
+						default:
 							str.removeSubscriber(i)
 						}
+					} else {
+						str.subscribers[i].connection <- event
 					}
 				}
 

--- a/stream.go
+++ b/stream.go
@@ -25,6 +25,12 @@ type Stream struct {
 	AutoReplay   bool
 	isAutoStream bool
 
+	// EvictSlowClients controls behaviour when a subscriber's event buffer is full.
+	// If true, the subscriber is immediately removed rather than blocking the
+	// fan-out goroutine. This prevents one stalled client from freezing all other
+	// connected clients. Defaults to false to preserve existing behaviour.
+	EvictSlowClients bool
+
 	// Specifies the function to run when client subscribe or un-subscribe
 	OnSubscribe   func(streamID string, sub *Subscriber)
 	OnUnsubscribe func(streamID string, sub *Subscriber)
@@ -74,8 +80,19 @@ func (str *Stream) run() {
 				if str.AutoReplay {
 					str.Eventlog.Add(event)
 				}
-				for i := range str.subscribers {
-					str.subscribers[i].connection <- event
+				for i := len(str.subscribers) - 1; i >= 0; i-- {
+					select {
+					case str.subscribers[i].connection <- event:
+					default:
+						if str.EvictSlowClients {
+							// Subscriber buffer is full — client is stalled.
+							// Call removeSubscriber directly rather than close()
+							// because we are inside stream.run() and close() would
+							// deadlock by sending to the deregister channel that
+							// only this goroutine reads.
+							str.removeSubscriber(i)
+						}
+					}
 				}
 
 			// Shutdown if the server closes


### PR DESCRIPTION
feat: add EvictSlowClients option to prevent slow subscribers blocking stream.run()

When a subscriber's 64-slot connection buffer is full, the original
fan-out loop blocks the entire stream.run() goroutine, freezing all
other connected clients until the slow client catches up or disconnects.

Add EvictSlowClients bool field to Stream. When true, a non-blocking
select/default evicts the stalled subscriber via removeSubscriber()
instead of blocking. When false (default), the event is dropped for
that subscriber but the goroutine continues — still an improvement
over the original blocking behavior.
